### PR TITLE
feat: add not found route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Dashboard from './pages/Dashboard';
 import ForgotPassword from './pages/ForgotPassword';
 import Login from './pages/Login';
 import Register from './pages/Register';
+import NotFound from "./pages/NotFound";
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
         <Route path="/dashboard"        element={<Dashboard />} />
         <Route path="/register"         element={<Register />} />
         <Route path="/forgot-password"  element={<ForgotPassword />} />
+        <Route path="*"                 element={<NotFound />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,24 @@
+import { House } from "lucide-react"
+import { useNavigate } from "react-router-dom"
+import Button from "../Components/button"
+
+export default function NotFound() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="flex flex-col items-center mt-50">
+      <h1 className="text-stone-800 text-5xl mb-2">404 - Página no encontrada</h1>
+      <p className="text-stone-400">La página que estás buscando no existe o fue movida.</p>
+
+      <div className="mt-6">
+        <Button
+          type="button"
+          onClick={() => navigate("/")}
+          className="flex items-center gap-2 px-5 py-2 shadow-md shadow-emerald-200 hover:shadow-lg hover:shadow-emerald-200 cursor-pointer">
+          <House size={18} />
+          Volver a inicio
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
This PR adds a 404 not found route and a NotFound component.

The NotFound.jsx page includes a button that redirects to the homepage using useNavigate(). The button reuses the same styling as the login page and the icon from the lucide library.

<p align="center">
  <img width="630" alt="Screenshot 2026-04-12 at 16 01 37"
       src="https://github.com/user-attachments/assets/7b587214-95ea-43aa-93b5-5c3fccf7bc3d" />
</p>